### PR TITLE
Fix front-end module exports and testing

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,6 +58,6 @@
         <button class="send-button">+</button>
     </footer>
 
-    <script type="module" src="graphView.js"></script>
+    <script type="module" src="src/view/app.js"></script>
 </body>
 </html> 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "epistema",
+  "type": "module",
+  "scripts": {
+    "test": "node tests/testGraphModel.js"
+  }
+}

--- a/src/model/graphModel.js
+++ b/src/model/graphModel.js
@@ -21,7 +21,7 @@
 // Graph data management
 import { NodeData } from './nodeModel.js';
 
-export class GraphData {
+export class GraphModel {
     constructor(onLoadCallback) {
         // Initialize nodes and links arrays
         this.nodes = [];
@@ -32,11 +32,11 @@ export class GraphData {
         this.onLoadCallback = onLoadCallback;
 
         try {
-            console.log("Loading initial data in GraphData constructor");
+            console.log("Loading initial data in GraphModel constructor");
             // Load sample data instead of trying to load from data/data.json
             this.loadInitialData();
         } catch (error) {
-            console.error("Error in GraphData constructor:", error);
+            console.error("Error in GraphModel constructor:", error);
             if (typeof this.onLoadCallback === 'function') {
                 console.log("Calling onLoadCallback with success=false");
                 this.onLoadCallback(false);

--- a/src/model/graphModel.js
+++ b/src/model/graphModel.js
@@ -46,30 +46,37 @@ export class GraphModel {
 
     // Load initial data from data/data.json - No longer used in constructor
     loadInitialData() {
-        fetch('data/data.json')
-            .then(response => {
-                if (!response.ok) {
-                    throw new Error('Failed to load data/data.json');
-                }
-                return response.json();
-            })
-            .then(data => {
-                if (this.loadFromData(data)) {
-                    console.log('Successfully loaded data from data/data.json');
-                    // Call the callback if provided
-                    if (typeof this.onLoadCallback === 'function') {
-                        this.onLoadCallback(true);
+        try {
+            fetch('data/data.json')
+                .then(response => {
+                    if (!response.ok) {
+                        throw new Error('Failed to load data/data.json');
                     }
-                } else {
+                    return response.json();
+                })
+                .then(data => {
+                    if (this.loadFromData(data)) {
+                        console.log('Successfully loaded data from data/data.json');
+                        // Call the callback if provided
+                        if (typeof this.onLoadCallback === 'function') {
+                            this.onLoadCallback(true);
+                        }
+                    } else {
+                        this.loadSampleData();
+                        // The callback will be called by loadSampleData
+                    }
+                })
+                .catch(error => {
+                    console.warn('Could not load data/data.json:', error);
                     this.loadSampleData();
                     // The callback will be called by loadSampleData
-                }
-            })
-            .catch(error => {
-                console.warn('Could not load data/data.json:', error);
-                this.loadSampleData();
-                // The callback will be called by loadSampleData
-            });
+                });
+        } catch (error) {
+            // Fetch can throw synchronously in some environments (e.g. Node)
+            console.warn('Could not load data/data.json:', error);
+            this.loadSampleData();
+            // The callback will be called by loadSampleData
+        }
     }
 
     // Load sample data as fallback

--- a/src/view/app.js
+++ b/src/view/app.js
@@ -1,4 +1,15 @@
-import { GraphModel } from './graphModel.js';
+import { GraphModel } from '../model/graphModel.js';
+import {
+  createVisualization,
+  enterCreationMode,
+  exitEditMode,
+  exitCreationMode,
+  centerGraph,
+  redrawGraph
+} from './graphView.js';
+import { addZoomControls } from './buttons.js';
+import { createNodeEditPanel, showNotification } from './modals.js';
+import { zoomToFitAllNodes } from './screenControls.js';
 
 // Initialize the application when the DOM is loaded
 function initApp() {

--- a/src/view/buttons.js
+++ b/src/view/buttons.js
@@ -1,6 +1,8 @@
+import { centerGraph } from './graphView.js';
+import { zoomToFitAllNodes } from './screenControls.js';
 
 // Add zoom control buttons to the container
-function addZoomControls(container, visualization) {
+export function addZoomControls(container, visualization) {
   const controlsContainer = document.createElement('div');
   controlsContainer.className = 'zoom-controls';
 

--- a/src/view/graphView.js
+++ b/src/view/graphView.js
@@ -1,18 +1,42 @@
+import {
+    drag,
+    toggleNodeSelection,
+    highlightSelectedNode,
+    unhighlightSelectedNode,
+    createPendingNodeCursor,
+    highlightPotentialParent,
+    createOrphanNode,
+    getNodeSize,
+    getFontSize,
+    getTextOffset,
+    getNodeColor
+} from './nodeView.js';
+import {
+    createNodeEditPanel,
+    showNodeEditUI,
+    hideNodeEditUI,
+    showNotification,
+    showCreationHelp,
+    hideCreationHelp
+} from './modals.js';
+import { zoomToFitAllNodes } from './screenControls.js';
+import { addZoomControls } from './buttons.js';
+
 let dataSource = '../data/data.json';
 
 // Create and initialize the graph data
-let graphModel;
-let visualization;
-let container;
+export let graphModel;
+export let visualization;
+export let container;
 
 // Initialize variables for edit mode and creation mode
-let selectedNode = null;
-let isEditMode = false;
-let isCreationMode = false;
-let pendingNodeText = '';
-let pendingNodeCursor = null;
+export let selectedNode = null;
+export let isEditMode = false;
+export let isCreationMode = false;
+export let pendingNodeText = '';
+export let pendingNodeCursor = null;
 let creationHelpText = null;
-let colorMap = {};
+export let colorMap = {};
 
 // Get the dimensions of the container
 function getScreenDimensions() {
@@ -67,7 +91,7 @@ function calculateGraphCentroid() {
 }
 
 // Create the D3 visualization
-function createVisualization() {
+export function createVisualization() {
     // Safety check - ensure graphModel is initialized
     if (!graphModel) {
         console.error("graphModel is not initialized!");
@@ -189,7 +213,7 @@ function createVisualization() {
 }
 
 // Enter edit mode
-function enterEditMode(node) {
+export function enterEditMode(node) {
     // Set the selected node
     selectedNode = node;
     isEditMode = true;
@@ -212,7 +236,7 @@ function enterEditMode(node) {
 }
 
 // Exit edit mode
-function exitEditMode() {
+export function exitEditMode() {
     if (!isEditMode) return;
 
     // Reset state
@@ -237,7 +261,7 @@ function exitEditMode() {
 }
 
 // Enter creation mode to select a parent or create an orphan
-function enterCreationMode(text) {
+export function enterCreationMode(text) {
     // Log for debugging
     console.log('Entering creation mode with text:', text);
 
@@ -275,7 +299,7 @@ function enterCreationMode(text) {
 }
 
 // Exit creation mode
-function exitCreationMode() {
+export function exitCreationMode() {
     if (!isCreationMode) return;
 
     isCreationMode = false;
@@ -297,10 +321,7 @@ function exitCreationMode() {
     }
 
     // Remove help text
-    if (creationHelpText) {
-        creationHelpText.remove();
-        creationHelpText = null;
-    }
+    hideCreationHelp();
 
     // Remove event listeners
     document.removeEventListener('mousemove', updateCursorPosition);
@@ -325,7 +346,7 @@ function updateCursorPosition(event) {
 }
 
 // Redraw the graph
-function redrawGraph() {
+export function redrawGraph() {
     // Clear the container
     container.innerHTML = '';
 
@@ -354,7 +375,7 @@ function redrawGraph() {
 }
 
 // Background click handler to exit edit mode or create orphan nodes
-function setupBackgroundClickHandler(svg) {
+export function setupBackgroundClickHandler(svg) {
     svg.on("click", (event) => {
         // Skip if the click came from a node
         if (event.target.closest && event.target.closest('.nodes g')) {
@@ -439,7 +460,7 @@ function addFileControls(container) {
 }
 
 // Function to center the graph by temporarily increasing the center force
-function centerGraph(simulation) {
+export function centerGraph(simulation) {
     // Get the current center force
     const centerForce = simulation.force("center");
     const { width, height } = getScreenDimensions();

--- a/src/view/modals.js
+++ b/src/view/modals.js
@@ -1,6 +1,10 @@
+import { saveNodeEdits } from './nodeView.js';
+import { exitEditMode, container } from './graphView.js';
+
+let creationHelpText = null;
 
 // Show a notification message
-function showNotification(message, type = 'success') {
+export function showNotification(message, type = 'success') {
   // Create notification element
   const notification = document.createElement('div');
   notification.className = `notification ${type}`;
@@ -30,7 +34,7 @@ function showNotification(message, type = 'success') {
 
 
 // Create the node edit panel
-function createNodeEditPanel(container) {
+export function createNodeEditPanel(container) {
   // Create the panel element
   const panel = document.createElement('div');
   panel.className = 'node-edit-panel';
@@ -77,7 +81,7 @@ function createNodeEditPanel(container) {
 
 
 // Show node editing UI
-function showNodeEditUI(node) {
+export function showNodeEditUI(node) {
   const panel = document.getElementById('node-edit-panel');
   if (!panel) return;
 
@@ -101,7 +105,7 @@ function showNodeEditUI(node) {
 }
 
 // Hide node editing UI
-function hideNodeEditUI() {
+export function hideNodeEditUI() {
   const panel = document.getElementById('node-edit-panel');
   if (panel) {
       panel.classList.remove('visible');
@@ -110,11 +114,18 @@ function hideNodeEditUI() {
 
 
 // Show help text for creation mode
-function showCreationHelp() {
+export function showCreationHelp() {
   creationHelpText = document.createElement('div');
   creationHelpText.className = 'creation-help-text';
   creationHelpText.innerHTML = 'Click on a node to <span>connect</span> or anywhere else to create <span>standalone</span> node. (Press ESC to cancel)';
 
   // Add to the container
   container.appendChild(creationHelpText);
+}
+
+export function hideCreationHelp() {
+  if (creationHelpText) {
+      creationHelpText.remove();
+      creationHelpText = null;
+  }
 }

--- a/src/view/nodeView.js
+++ b/src/view/nodeView.js
@@ -1,6 +1,19 @@
+import {
+  exitEditMode,
+  exitCreationMode,
+  redrawGraph,
+  graphModel,
+  visualization,
+  container,
+  isCreationMode,
+  isEditMode,
+  pendingNodeText,
+  selectedNode
+} from './graphView.js';
+import { showNotification } from './modals.js';
 
 // Save node edits
-function saveNodeEdits() {
+export function saveNodeEdits() {
   if (!selectedNode) return;
 
   // Get values from inputs
@@ -40,7 +53,7 @@ function saveNodeEdits() {
 }
 
 // Update node visualization after editing
-function updateNodeVisual(node) {
+export function updateNodeVisual(node) {
   // Find the node element
   const nodeElements = document.querySelectorAll('.nodes > g');
 
@@ -75,7 +88,7 @@ function updateNodeVisual(node) {
 
 
 // Calculate node size based on number of descendants
-function getNodeSize(node) {
+export function getNodeSize(node) {
   // Base size for nodes without children
   const baseSize = node.parentID === null ? 18 : 15;
 
@@ -95,7 +108,7 @@ function getNodeSize(node) {
 }
 
 // Calculate font size based on node size
-function getFontSize(node) {
+export function getFontSize(node) {
   // Base font size
   const baseFontSize = 10;
 
@@ -115,7 +128,7 @@ function getFontSize(node) {
 }
 
 // Calculate text vertical position based on node size
-function getTextOffset(node) {
+export function getTextOffset(node) {
   // Base offset
   const baseOffset = node.parentID === null ? 30 : 25;
 
@@ -134,7 +147,7 @@ function getTextOffset(node) {
 
 
 // Get color based on node type
-function getNodeColor(type) {
+export function getNodeColor(type) {
 
   // Check if type is in colorMap, if not, add it as new field and pick from the available colors at random
   if ( colorMap[type] ) {
@@ -151,7 +164,7 @@ function getNodeColor(type) {
 }
 
 // Implement drag behavior for nodes
-function drag(simulation) {
+export function drag(simulation) {
   function dragstarted(event, d) {
       // Don't start drag if we're in creation mode
       if (isCreationMode) {
@@ -188,7 +201,7 @@ function drag(simulation) {
 }
 
 // Toggle node selection
-function toggleNodeSelection(node, svg) {
+export function toggleNodeSelection(node, svg) {
   // If in creation mode, handle parent selection
   if (isCreationMode) {
       console.log('Node clicked in creation mode - creating child node with parent:', node.id);
@@ -207,7 +220,7 @@ function toggleNodeSelection(node, svg) {
 
 
 // Highlight the selected node
-function highlightSelectedNode(node) {
+export function highlightSelectedNode(node) {
   // Find the node element in the DOM
   const nodeElements = document.querySelectorAll('.nodes > g');
 
@@ -226,7 +239,7 @@ function highlightSelectedNode(node) {
 }
 
 // Remove highlighting from all nodes
-function unhighlightSelectedNode() {
+export function unhighlightSelectedNode() {
   const nodeElements = document.querySelectorAll('.nodes > g');
   nodeElements.forEach(el => {
       el.classList.remove('selected');
@@ -234,7 +247,7 @@ function unhighlightSelectedNode() {
 }
 
 // Create a pending node cursor that follows the mouse
-function createPendingNodeCursor() {
+export function createPendingNodeCursor() {
   pendingNodeCursor = document.createElement('div');
   pendingNodeCursor.className = 'pending-node-cursor';
   pendingNodeCursor.id = 'pending-node-cursor';
@@ -245,7 +258,7 @@ function createPendingNodeCursor() {
 
 
 // Highlight node under cursor as potential parent
-function highlightPotentialParent(event) {
+export function highlightPotentialParent(event) {
   // Get mouse position
   const containerRect = container.getBoundingClientRect();
   const mouseX = event.clientX - containerRect.left;
@@ -294,7 +307,7 @@ function highlightPotentialParent(event) {
 }
 
 // Create a new node with a parent
-function createNodeWithParent(parentId) {
+export function createNodeWithParent(parentId) {
   console.log('Creating node with parent, text:', pendingNodeText, 'parentId:', parentId);
 
   if (!pendingNodeText) {
@@ -330,7 +343,7 @@ function createNodeWithParent(parentId) {
 }
 
 // Create an orphan node at current cursor position
-function createOrphanNode() {
+export function createOrphanNode() {
   console.log('Creating orphan node, text:', pendingNodeText);
 
   if (!pendingNodeText) {

--- a/src/view/screenControls.js
+++ b/src/view/screenControls.js
@@ -1,6 +1,5 @@
-
 // Function to zoom out to fit all nodes in the viewport
-function zoomToFitAllNodes(visualization) {
+export function zoomToFitAllNodes(visualization) {
   // Safety check
   if (!visualization || !visualization.nodeGroup || !graphModel || graphModel.getNodes().length === 0) {
       console.warn("Cannot zoom to fit: visualization or nodes not available");

--- a/tests/testGraphModel.js
+++ b/tests/testGraphModel.js
@@ -1,0 +1,22 @@
+import { GraphModel } from '../src/model/graphModel.js';
+
+(async () => {
+  const model = new GraphModel(() => {});
+  // Wait briefly for possible async operations
+  await new Promise(r => setTimeout(r, 100));
+  if (model.nodes.length !== 5) {
+    console.error('Expected 5 nodes on load');
+    process.exit(1);
+  }
+  const count = model.countDescendants(1);
+  if (count !== 4) {
+    console.error('Expected 4 descendants for node 1');
+    process.exit(1);
+  }
+  model.addNode('Test', 2);
+  if (model.nodes.length !== 6) {
+    console.error('Node was not added');
+    process.exit(1);
+  }
+  console.log('All tests passed');
+})();

--- a/ui.html
+++ b/ui.html
@@ -6,7 +6,7 @@
   <title>Epistema</title>
   <link rel="stylesheet" href="styles.css">
   <script src="https://cdn.jsdelivr.net/npm/d3@7"></script>
-  <script type="module" src="graphView.js"></script>
+  <script type="module" src="src/view/app.js"></script>
 </head>
 <body>
   <header>


### PR DESCRIPTION
## Summary
- rename `GraphData` class to `GraphModel`
- correct script path in HTML files
- convert view scripts to ES modules with explicit exports
- add simple Node based test for the model

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fab3855a0832fa3ae191c8abb86c1